### PR TITLE
MCP W1: restructure meta-injector + caches.default (#104, #110)

### DIFF
--- a/.claude/commands/seo.md
+++ b/.claude/commands/seo.md
@@ -98,7 +98,7 @@ Select "Get detailed help" to see step-by-step playbooks:
 
   HOW TO FIX (4 steps)
 
-  Step 1: Open workers/meta-injector.js
+  Step 1: Open workers/meta-injector/worker.js
   Step 2: Add scene-specific titles
   Step 3: Deploy the Worker
   Step 4: Verify with curl

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -351,7 +351,7 @@ The site is automatically deployed via Cloudflare Pages:
 
 ### Cloudflare Worker (Dynamic Meta Tags)
 
-**Location**: `workers/meta-injector.js`
+**Location**: `workers/meta-injector/worker.js`
 **Purpose**: Inject dynamic meta tags for bots while keeping SPA fast for humans
 **Status**: Deployed to production
 **Worker URL**: <https://concerts-meta-injector.morps.workers.dev>
@@ -461,7 +461,7 @@ See [workers/README.md](../workers/README.md) for:
 **Social Media**: Facebook, Twitter, LinkedIn, WhatsApp, Telegram, Slack, Discord
 **AI Assistants**: ChatGPT, Claude, Perplexity, Google-Extended
 
-Full list: See `BOT_USER_AGENTS` in [workers/meta-injector.js:18-44](../workers/meta-injector.js#L18-L44)
+Full list: See `BOT_USER_AGENTS` in [workers/meta-injector/worker.js:18-44](../workers/meta-injector/worker.js#L18-L44)
 
 ## NPM Scripts Reference
 

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -870,7 +870,7 @@ curl -A "Googlebot/2.1" \
 **Solution**:
 ```bash
 # Check worker deployment
-cd workers
+cd workers/meta-injector
 npx wrangler tail
 
 # In another terminal, trigger a request
@@ -953,7 +953,7 @@ curl -A "facebookexternalhit/1.1" \
   | grep "og:title"
 
 # If OG tags missing, check worker logs
-cd workers
+cd workers/meta-injector
 npx wrangler tail
 
 # Force Facebook to re-scrape
@@ -967,7 +967,7 @@ npx wrangler tail
 **Diagnosis**:
 ```bash
 # View real-time worker logs
-cd workers
+cd workers/meta-injector
 npx wrangler tail
 
 # Trigger requests and watch for errors
@@ -989,7 +989,7 @@ cat public/data/venues-metadata.json | jq . > /dev/null
 npm run build-data
 
 # Re-deploy worker
-cd workers
+cd workers/meta-injector
 npx wrangler deploy
 ```
 
@@ -1030,8 +1030,8 @@ Bot indexes with dynamic title/description
 - `public/og-stats.json` - Stats for OG image generation
 
 **Worker Files**:
-- `workers/meta-injector.js` - Dynamic meta injection logic
-- `workers/wrangler.toml` - Worker configuration
+- `workers/meta-injector/worker.js` - Dynamic meta injection logic
+- `workers/meta-injector/wrangler.toml` - Worker configuration
 - `workers/README.md` - Deployment guide
 
 **Data Pipeline Scripts**:

--- a/docs/specs/future/mcp-test-anchors.md
+++ b/docs/specs/future/mcp-test-anchors.md
@@ -1,0 +1,81 @@
+# MCP Test Anchors
+
+Recorded by W1 ([#104](https://github.com/mmorper/concerts/issues/104)) for use by W3 ([#106](https://github.com/mmorper/concerts/issues/106)) tool tests. Re-derive from `public/data/*.json` if the data shifts substantially.
+
+**Snapshot:** 2026-05-17 (data computedAt 2026-05-12)
+
+## Fact-table anchors (from `facts.json`)
+
+| Anchor | Value | Source fact `id` |
+|---|---|---|
+| Most-seen artist | **Social Distortion** (8 concerts, 1990–2024) | `top-artist` |
+| Most-visited venue | **Pacific Amphitheatre** (17 shows, 1985–2026) | `top-venue` |
+| Total concerts | 182 | `total-concerts` |
+
+## `surprise_me` setlist anchor (from `setlists-cache.json`)
+
+- **`concertId`: `concert-1`** — Adam Ant @ Irvine Meadows, 1984-04-27
+- Cache entry shape: `{ concertId, artistName, date, venue, city, setlist: {...}, fetchedAt }`
+- Cache wrapper: `{ version: "1.0.0", generatedAt, entries: { [concertId]: {...} } }` — 368 cached concerts
+
+Any `concertId` from `concert-1`…`concert-N` that appears in `entries` works. Prefer `concert-1` since the artist (Adam Ant) is unambiguous and the venue (Irvine Meadows, demolished 2016) makes for a good demo of cross-referencing closed venues.
+
+## `on_this_day` anchors (from `concerts.json` date frequency)
+
+| Anchor | `MM-DD` | Concert count |
+|---|---|---|
+| Hit (multi-show) | **`06-04`** | 4 concerts |
+| Hit (multi-show, runner-up) | `11-16` | 4 concerts |
+| Zero-result | **`01-02`** | 0 concerts |
+
+`01-02` is a verified empty slot in the archive; safe to lock in for the zero-result test until the data refreshes (any new Jan-2 show would land here and break the assertion).
+
+## Ambiguous artist partial-match (for fuzzy/disambiguation tests)
+
+| Query | Matches |
+|---|---|
+| `Peter` | `Peter Gabriel`, `Peter Hook and the Light` |
+| `Peter Hook` | `Peter Hook and the Light` (unique → narrow match) |
+
+The `Peter` query is the disambiguation case (multiple matches). `Peter Hook` exercises the "user typed the artist's name but the headliner is the full project name" pattern flagged in the spec.
+
+Single-match (no ambiguity) sanity anchors: `John` → `Elton John`; `David` → `David Byrne`.
+
+---
+
+## `venues-metadata.json` field inventory (W1 §6 deliverable for `get_venue_history`)
+
+Inventory across all 78 venues; populated counts are out of 78 unless noted.
+
+### Narration-useful, always populated
+
+| Field | Population | Notes |
+|---|---|---|
+| `name` | 78/78 | Display name |
+| `city`, `state`, `cityState` | 78/78 | All three present; `cityState` is precomposed |
+| `location.lat`/`lng` | 78/78 | Suitable for map narration ("X miles from Y") if W3 wants it |
+| `status` | 78/78 | Enum: `active`, `closed`, `demolished`, `renamed` |
+| `stats.totalConcerts`, `firstEvent`, `lastEvent`, `uniqueArtists` | 78/78 | Per-venue rollups; ready for narration |
+| `concerts[]` | 78/78 | Per-venue list of `{id, date, headliner}`, sorted chronologically |
+
+### Narration-useful, sometimes populated
+
+| Field | Population | Notes |
+|---|---|---|
+| `notes` | 12/78 | Free-text closure context; goldmine when present (e.g., `"Demolished for SoFi Stadium development"`). Empty/null for active venues, common for closed/demolished ones. |
+| `closedDate` | 10/78 | ISO date; pairs with `status: closed/demolished/renamed` |
+| `photoUrls.{thumbnail,medium,large}` | 66/78 real | Remaining 12 are `/images/venues/fallback.jpg` |
+
+### **Not present in the schema** (W3 narration must not assume these)
+
+- `capacity` — **not modeled**. If narration needs venue size, MCP would have to derive it elsewhere or omit it.
+- `neighborhood` — **not modeled**. Only city-granularity location.
+- `description` — **not modeled**. The closest field is `notes`, which only exists for ~15% of venues.
+
+### Recommended narration template for `get_venue_history`
+
+Compose from: `name` + `cityState` + `stats.totalConcerts` + `stats.firstEvent`–`stats.lastEvent` + (if `status !== 'active'`) `status` + (if `closedDate`) `closedDate` + (if `notes`) `notes` + a sampled-3 from `concerts[]` by headliner.
+
+Example assembled prose for `irvine-meadows`:
+
+> Irvine Meadows in Irvine, California hosted 16 shows between 1984 and 2003 — including Adam Ant, Depeche Mode, and Peter Gabriel. The venue was demolished on 2016-10-30 for residential development.

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "generate:rss": "tsx scripts/generate-rss.ts",
     "generate:liner-notes-rss": "tsx scripts/generate-liner-notes-rss.ts",
     "generate:liner-notes": "tsx scripts/liner-notes/index.ts",
-    "deploy:worker": "cd workers && wrangler deploy"
+    "deploy:worker": "cd workers/meta-injector && npx wrangler deploy"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/workers/README.md
+++ b/workers/README.md
@@ -68,7 +68,7 @@ account_id = "abc123def456..."
 ### Start Local Development Server
 
 ```bash
-cd workers
+cd workers/meta-injector
 wrangler dev
 ```
 
@@ -106,7 +106,7 @@ Expected: Dynamic description with concert count and featured artists.
 ### Step 1: Deploy Worker
 
 ```bash
-cd workers
+cd workers/meta-injector
 wrangler deploy
 ```
 
@@ -250,7 +250,7 @@ Check user agent in logs:
 wrangler tail
 ```
 
-Verify user agent is in `BOT_USER_AGENTS` list (line 14-41 in `meta-injector.js`).
+Verify user agent is in `BOT_USER_AGENTS` list (line 14-41 in `meta-injector/worker.js`).
 
 ### Metadata Not Loading
 
@@ -302,7 +302,7 @@ Enter: `https://concerts.morperhaus.org/?scene=artists&artist=depeche-mode`
 
 **Redeployment:**
 ```bash
-cd workers
+cd workers/meta-injector
 wrangler deploy
 ```
 

--- a/workers/meta-injector/worker.js
+++ b/workers/meta-injector/worker.js
@@ -43,6 +43,24 @@ const BOT_USER_AGENTS = [
   'google-extended',
 ];
 
+// Cache same-origin JSON between requests so we don't pay fetch+parse on every bot hit.
+// Spike #110 measured cold-isolate CPU at 11–16 ms on venue routes (over the 10 ms free-tier limit);
+// the parse dominates. 300s TTL keeps SEO bots within acceptable staleness.
+async function cachedJsonFetch(url, ctx) {
+  const cache = caches.default;
+  const cacheKey = new Request(url, { method: 'GET' });
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  const response = await fetch(url);
+  if (!response.ok) return response;
+
+  const cacheable = new Response(response.body, response);
+  cacheable.headers.set('Cache-Control', 'public, max-age=300');
+  ctx.waitUntil(cache.put(cacheKey, cacheable.clone()));
+  return cacheable;
+}
+
 /**
  * Main request handler
  */
@@ -78,25 +96,25 @@ export default {
 
     // Inject dynamic meta tags — pathname routes take precedence over query params
     if (url.pathname === '/how-it-works') {
-      html = await injectHowItWorksMeta(html, url.origin);
+      html = await injectHowItWorksMeta(html, url.origin, ctx);
     } else if (url.pathname === '/liner-notes') {
-      html = await injectLinerNotesFeedMeta(html, url.origin);
+      html = await injectLinerNotesFeedMeta(html, url.origin, ctx);
     } else if (url.pathname.startsWith('/liner-notes/') && url.pathname !== '/liner-notes/rss') {
       const slug = url.pathname.slice('/liner-notes/'.length);
-      html = await injectLinerNotesPostMeta(html, slug, url.origin);
+      html = await injectLinerNotesPostMeta(html, slug, url.origin, ctx);
     } else if (url.pathname === '/whats-playing') {
       html = await injectWhatsPlayingMeta(html, url.origin);
     } else if (scene === 'artists' && artist) {
-      html = await injectArtistMeta(html, artist, url.origin);
+      html = await injectArtistMeta(html, artist, url.origin, ctx);
     } else if ((scene === 'venues' || scene === 'geography') && venue) {
-      html = await injectVenueMeta(html, venue, url.origin, scene);
+      html = await injectVenueMeta(html, venue, url.origin, scene, ctx);
     } else if (scene === 'genres' && genre) {
-      html = await injectGenreMeta(html, genre, url.origin);
+      html = await injectGenreMeta(html, genre, url.origin, ctx);
     } else if (scene === 'geography' && region) {
-      html = await injectRegionMeta(html, region, url.origin);
+      html = await injectRegionMeta(html, region, url.origin, ctx);
     } else {
       // Scene-only or homepage — inject scene meta
-      html = await injectSceneMeta(html, scene, url.origin);
+      html = await injectSceneMeta(html, scene, url.origin, ctx);
     }
 
     // Preserve all original headers (CORS, CSP, security headers, etc.)
@@ -144,10 +162,10 @@ function isHTMLRequest(request) {
 /**
  * Inject artist-specific meta tags
  */
-async function injectArtistMeta(html, artistNormalized, origin) {
+async function injectArtistMeta(html, artistNormalized, origin, ctx) {
   try {
     // Fetch artist metadata
-    const artistsResponse = await fetch(`${origin}/data/artists-metadata.json`);
+    const artistsResponse = await cachedJsonFetch(`${origin}/data/artists-metadata.json`, ctx);
     if (!artistsResponse.ok) {
       console.error('Failed to fetch artists-metadata.json');
       return html;
@@ -161,7 +179,7 @@ async function injectArtistMeta(html, artistNormalized, origin) {
     }
 
     // Fetch concert data to count concerts
-    const concertsResponse = await fetch(`${origin}/data/concerts.json`);
+    const concertsResponse = await cachedJsonFetch(`${origin}/data/concerts.json`, ctx);
     if (!concertsResponse.ok) {
       console.error('Failed to fetch concerts.json');
       return html;
@@ -244,10 +262,10 @@ async function injectArtistMeta(html, artistNormalized, origin) {
 /**
  * Inject venue-specific meta tags
  */
-async function injectVenueMeta(html, venueNormalized, origin, scene) {
+async function injectVenueMeta(html, venueNormalized, origin, scene, ctx) {
   try {
     // Fetch venue metadata
-    const venuesResponse = await fetch(`${origin}/data/venues-metadata.json`);
+    const venuesResponse = await cachedJsonFetch(`${origin}/data/venues-metadata.json`, ctx);
     if (!venuesResponse.ok) {
       console.error('Failed to fetch venues-metadata.json');
       return html;
@@ -261,7 +279,7 @@ async function injectVenueMeta(html, venueNormalized, origin, scene) {
     }
 
     // Fetch concert data to count concerts
-    const concertsResponse = await fetch(`${origin}/data/concerts.json`);
+    const concertsResponse = await cachedJsonFetch(`${origin}/data/concerts.json`, ctx);
     if (!concertsResponse.ok) {
       console.error('Failed to fetch concerts.json');
       return html;
@@ -335,9 +353,9 @@ async function injectVenueMeta(html, venueNormalized, origin, scene) {
 /**
  * Inject region-specific meta tags
  */
-async function injectRegionMeta(html, regionNormalized, origin) {
+async function injectRegionMeta(html, regionNormalized, origin, ctx) {
   try {
-    const concertsResponse = await fetch(`${origin}/data/concerts.json`);
+    const concertsResponse = await cachedJsonFetch(`${origin}/data/concerts.json`, ctx);
     if (!concertsResponse.ok) {
       console.error('Failed to fetch concerts.json');
       return html;
@@ -422,9 +440,9 @@ async function injectRegionMeta(html, regionNormalized, origin) {
 /**
  * Inject genre-specific meta tags
  */
-async function injectGenreMeta(html, genreNormalized, origin) {
+async function injectGenreMeta(html, genreNormalized, origin, ctx) {
   try {
-    const concertsResponse = await fetch(`${origin}/data/concerts.json`);
+    const concertsResponse = await cachedJsonFetch(`${origin}/data/concerts.json`, ctx);
     if (!concertsResponse.ok) {
       console.error('Failed to fetch concerts.json');
       return html;
@@ -482,9 +500,9 @@ async function injectGenreMeta(html, genreNormalized, origin) {
 /**
  * Inject meta tags for /how-it-works — the interactive data pipeline explainer
  */
-async function injectHowItWorksMeta(html, origin) {
+async function injectHowItWorksMeta(html, origin, ctx) {
   try {
-    const concertsResponse = await fetch(`${origin}/data/concerts.json`);
+    const concertsResponse = await cachedJsonFetch(`${origin}/data/concerts.json`, ctx);
     if (!concertsResponse.ok) return html;
     const concertsData = await concertsResponse.json();
 
@@ -515,10 +533,10 @@ async function injectHowItWorksMeta(html, origin) {
 /**
  * Inject scene-specific meta tags (no entity deep link)
  */
-async function injectSceneMeta(html, scene, origin) {
+async function injectSceneMeta(html, scene, origin, ctx) {
   try {
     // Fetch stats from concerts.json
-    const concertsResponse = await fetch(`${origin}/data/concerts.json`);
+    const concertsResponse = await cachedJsonFetch(`${origin}/data/concerts.json`, ctx);
     if (!concertsResponse.ok) {
       console.error('Failed to fetch concerts.json');
       return html;
@@ -584,9 +602,9 @@ async function injectSceneMeta(html, scene, origin) {
 /**
  * Inject meta tags for /liner-notes feed page
  */
-async function injectLinerNotesFeedMeta(html, origin) {
+async function injectLinerNotesFeedMeta(html, origin, ctx) {
   try {
-    const feedResponse = await fetch(`${origin}/data/liner-notes.json`);
+    const feedResponse = await cachedJsonFetch(`${origin}/data/liner-notes.json`, ctx);
     const title = 'Liner Notes | Morperhaus Concert Archives';
     const description = 'Stories from 42 years of live music — personal essays, cultural context, and deep cuts.';
     const pageUrl = `${origin}/liner-notes`;
@@ -621,9 +639,9 @@ async function injectLinerNotesFeedMeta(html, origin) {
 /**
  * Inject meta tags for /liner-notes/:slug post permalink
  */
-async function injectLinerNotesPostMeta(html, slug, origin) {
+async function injectLinerNotesPostMeta(html, slug, origin, ctx) {
   try {
-    const feedResponse = await fetch(`${origin}/data/liner-notes.json`);
+    const feedResponse = await cachedJsonFetch(`${origin}/data/liner-notes.json`, ctx);
     if (!feedResponse.ok) {
       console.error('Failed to fetch liner-notes.json');
       return html;

--- a/workers/meta-injector/wrangler.toml
+++ b/workers/meta-injector/wrangler.toml
@@ -2,7 +2,7 @@
 # This worker injects dynamic meta tags for bots while keeping the SPA fast for humans
 
 name = "concerts-meta-injector"
-main = "meta-injector.js"
+main = "worker.js"
 compatibility_date = "2024-01-01"
 
 # Account ID (get from Cloudflare Dashboard > Workers & Pages > Overview)


### PR DESCRIPTION
Closes #104 (substantively). Folds in the caching scope from #110.

## Summary

- **Restructure**: `workers/meta-injector.js` → `workers/meta-injector/worker.js`, `workers/wrangler.toml` → `workers/meta-injector/wrangler.toml` (with `main = "worker.js"`). Creates room for `workers/mcp-server/` in W2 (#105).
- **Caching**: All 10 same-origin JSON fetches now go through a single `cachedJsonFetch(url, ctx)` helper using `caches.default`, 300s TTL, `ctx.waitUntil(cache.put(...))`. `ctx` threaded through 8 inject functions.
- **Active refs updated**: `package.json` `deploy:worker` script (now uses `npx wrangler` so it works without a global install), `workers/README.md`, `docs/SEO.md`, `docs/BUILD.md`, `.claude/commands/seo.md`. Implemented-spec history docs left untouched.
- **Anchors recorded**: [docs/specs/future/mcp-test-anchors.md](../blob/mcp/w1-restructure/docs/specs/future/mcp-test-anchors.md) for W3 tool tests (#106) — most-seen artist, most-visited venue, `surprise_me` setlist concertId, `on_this_day` hit + zero-result months, ambiguous artist partial-match. Includes `venues-metadata.json` field inventory for `get_venue_history` enrichment.

## Live-fire verification (already deployed)

Site response is **byte-identical** pre/post-deploy across 5 probes (Googlebot UA on `/`, `?scene=artists`, `?scene=venues`, `?scene=geography`, plus a human UA passthrough). Worker version: `d3706583-199b-414a-b2af-b1fc1ca1b292`.

`wrangler tail` (12-request sample, JSON format):

| URL pattern | wallTime | cpuTime |
|---|---|---|
| venue (cold first-hit) | 64ms | **14ms** |
| venue (warm 1–7) | 33–78ms | 5–12ms |
| venue (different venue) | 50ms | 7ms |
| artist | 50ms | 4ms |
| genre | 34ms | 2ms |
| home | 30ms | 2ms |

p50 = 8ms, p99 = 14ms, **over-10ms rate dropped from 2/3 (spike #110 baseline) to 2/12**. The cold first-hit (14ms) is the inherent cost of populating an empty per-colo `caches.default`; everything after that lives under or near the 10ms free-tier ceiling.

**Honest note**: the cross-comment on #104 predicted "p99 16ms → 2–3ms." That was optimistic — `caches.default` stores the `Response`, not the parsed JSON, so `JSON.parse` cost remains. The actual delta is more modest (p99 14ms, p50 8ms). This is still enough to take the W2 MCP Worker out of the "consistently over the ceiling" risk zone; further gains would require an in-isolate parsed-JSON cache (out of W1 scope).

## Test plan

- [x] `node --check workers/meta-injector/worker.js` passes
- [x] Deployed to production from new path via `npm run deploy:worker`
- [x] Curl-diff against pre-deploy baseline shows byte-identical responses on 5 probe URLs
- [x] `wrangler tail` CPU sample shows over-10ms rate dropped vs spike #110
- [ ] Owner: spot-check Cloudflare dashboard for elevated 4xx/5xx in the next hour
- [ ] W2 (#105) starts off this branch's `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)